### PR TITLE
BF: set --no-update-index for wheel upload

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ environment:
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
       APPVEYOR_SKIP_FINALIZE_ON_EXIT: true
       CONTAINER: wheels
+      UPLOAD_ARGS: "--no-update-index"
       WHEELHOUSE_UPLOADER_USERNAME: travis-worker
       WHEELHOUSE_UPLOADER_SECRET:
         secure:


### PR DESCRIPTION
Upload to the wheels container should not update the index.html file,
because, by convention, we use the Rackspace file listings to present
the directory contents.

By the way - any chance of detaching this from the scipy-wheels repo?  It's
impossible to fork this repo properly at the moment...